### PR TITLE
Make optional properties false by default.

### DIFF
--- a/gmaps.js
+++ b/gmaps.js
@@ -774,9 +774,9 @@ var GMaps = (function($) {
       }
 
       var base_options = {
-        avoidHighways: true,
-        avoidTolls: true,
-        optimizeWaypoints: true,
+        avoidHighways: false,
+        avoidTolls: false,
+        optimizeWaypoints: false,
         waypoints: []
       };
       var request_options = $.extend(base_options, options);


### PR DESCRIPTION
According to the [API docs](https://developers.google.com/maps/documentation/javascript/reference#DirectionsRequest), `avoidHighways` and `avoidTolls` are optional bools. Given this, I think it makes more sense to make them false by default. (Also `optimizeWaypoints` seems to be optional as well, but not explicitly mentioned.)
