### PR TITLE
Enable seamless usage with RequireJS and async plugin

### DIFF
--- a/gmaps.js
+++ b/gmaps.js
@@ -10,6 +10,7 @@ var GMaps = (function($) {
   "use strict";
 
   var GMaps = function(options) {
+    GMaps.initialize();
     var self = this;
     var context_menu_style = 'position:absolute;display:none;min-width:100px;' +
       'background:white;list-style:none;padding:8px;box-shadow:2px 2px 6px #ccc';
@@ -779,6 +780,7 @@ var GMaps = (function($) {
   };
 
   GMaps.Route = function(options) {
+    GMaps.initialize();
     this.map = options.map;
     this.route = options.route;
     this.step_count = 0;
@@ -819,6 +821,7 @@ var GMaps = (function($) {
 
   // Geolocation (Modern browsers only)
   GMaps.geolocate = function(options) {
+    GMaps.initialize();
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(function(position) {
         options.success(position);
@@ -842,6 +845,7 @@ var GMaps = (function($) {
 
   // Geocoding
   GMaps.geocode = function(options) {
+    GMaps.initialize();
     this.geocoder = new google.maps.Geocoder();
     var callback = options.callback;
     if (options.lat && options.lng) {
@@ -858,6 +862,7 @@ var GMaps = (function($) {
 
   // Static maps
   GMaps.staticMapURL = function(options){
+    GMaps.initialize();
     var parameters = [];
     var data;
 
@@ -1018,74 +1023,80 @@ var GMaps = (function($) {
     return static_root + parameters;
   };
 
-  //==========================
-  // Polygon containsLatLng
-  // https://github.com/tparkin/Google-Maps-Point-in-Polygon
-  // Poygon getBounds extension - google-maps-extensions
-  // http://code.google.com/p/google-maps-extensions/source/browse/google.maps.Polygon.getBounds.js
-  if (!google.maps.Polygon.prototype.getBounds) {
-    google.maps.Polygon.prototype.getBounds = function(latLng) {
-      var bounds = new google.maps.LatLngBounds();
-      var paths = this.getPaths();
-      var path;
+  GMaps.initialize = function() {
+    if (!GMaps.hasInitialized) {
+        //==========================
+        // Polygon containsLatLng
+        // https://github.com/tparkin/Google-Maps-Point-in-Polygon
+        // Poygon getBounds extension - google-maps-extensions
+        // http://code.google.com/p/google-maps-extensions/source/browse/google.maps.Polygon.getBounds.js
+        if (!google.maps.Polygon.prototype.getBounds) {
+          google.maps.Polygon.prototype.getBounds = function(latLng) {
+            var bounds = new google.maps.LatLngBounds();
+            var paths = this.getPaths();
+            var path;
 
-      for (var p = 0; p < paths.getLength(); p++) {
-        path = paths.getAt(p);
-        for (var i = 0; i < path.getLength(); i++) {
-          bounds.extend(path.getAt(i));
+            for (var p = 0; p < paths.getLength(); p++) {
+              path = paths.getAt(p);
+              for (var i = 0; i < path.getLength(); i++) {
+                bounds.extend(path.getAt(i));
+              }
+            }
+
+            return bounds;
+          };
         }
-      }
 
-      return bounds;
-    };
-  }
+        // Polygon containsLatLng - method to determine if a latLng is within a polygon
+        google.maps.Polygon.prototype.containsLatLng = function(latLng) {
+          // Exclude points outside of bounds as there is no way they are in the poly
+          var bounds = this.getBounds();
 
-  // Polygon containsLatLng - method to determine if a latLng is within a polygon
-  google.maps.Polygon.prototype.containsLatLng = function(latLng) {
-    // Exclude points outside of bounds as there is no way they are in the poly
-    var bounds = this.getBounds();
-
-    if (bounds !== null && !bounds.contains(latLng)) {
-      return false;
-    }
-
-    // Raycast point in polygon method
-    var inPoly = false;
-
-    var numPaths = this.getPaths().getLength();
-    for (var p = 0; p < numPaths; p++) {
-      var path = this.getPaths().getAt(p);
-      var numPoints = path.getLength();
-      var j = numPoints - 1;
-
-      for (var i = 0; i < numPoints; i++) {
-        var vertex1 = path.getAt(i);
-        var vertex2 = path.getAt(j);
-
-        if (vertex1.lng() < latLng.lng() && vertex2.lng() >= latLng.lng() || vertex2.lng() < latLng.lng() && vertex1.lng() >= latLng.lng()) {
-          if (vertex1.lat() + (latLng.lng() - vertex1.lng()) / (vertex2.lng() - vertex1.lng()) * (vertex2.lat() - vertex1.lat()) < latLng.lat()) {
-            inPoly = !inPoly;
+          if (bounds !== null && !bounds.contains(latLng)) {
+            return false;
           }
-        }
 
-        j = i;
-      }
+          // Raycast point in polygon method
+          var inPoly = false;
+
+          var numPaths = this.getPaths().getLength();
+          for (var p = 0; p < numPaths; p++) {
+            var path = this.getPaths().getAt(p);
+            var numPoints = path.getLength();
+            var j = numPoints - 1;
+
+            for (var i = 0; i < numPoints; i++) {
+              var vertex1 = path.getAt(i);
+              var vertex2 = path.getAt(j);
+
+              if (vertex1.lng() < latLng.lng() && vertex2.lng() >= latLng.lng() || vertex2.lng() < latLng.lng() && vertex1.lng() >= latLng.lng()) {
+                if (vertex1.lat() + (latLng.lng() - vertex1.lng()) / (vertex2.lng() - vertex1.lng()) * (vertex2.lat() - vertex1.lat()) < latLng.lat()) {
+                  inPoly = !inPoly;
+                }
+              }
+
+              j = i;
+            }
+          }
+
+          return inPoly;
+        };
+
+        google.maps.LatLngBounds.prototype.containsLatLng = function(latLng) {
+          return this.contains(latLng);
+        };
+
+        google.maps.Marker.prototype.setFences = function(fences) {
+          this.fences = fences;
+        };
+
+        google.maps.Marker.prototype.addFence = function(fence) {
+          this.fences.push(fence);
+        };
+
+        GMaps.hasInitialized == true;
     }
-
-    return inPoly;
-  };
-
-  google.maps.LatLngBounds.prototype.containsLatLng = function(latLng) {
-    return this.contains(latLng);
-  };
-
-  google.maps.Marker.prototype.setFences = function(fences) {
-    this.fences = fences;
-  };
-
-  google.maps.Marker.prototype.addFence = function(fence) {
-    this.fences.push(fence);
-  };
+  }
 
   return GMaps;
 }(jQuery || $));


### PR DESCRIPTION
Great plugin, i've just had to make one little adjustment so I could use it with RequireJS in one of my projects.

To load googlemaps with RequireJS i had to use the async plugin and you're code was throwing an error since it access google.maps.\* code in it's first run. I've just create a wrapper method and make sure it ran only once the first time it was needed. This allowed me to use a single require statement instead of nesting requires.

I.E.:

require(["google/gmaps","async!http://maps.googleapis.com/maps/api/js?sensor=false!callback"], function() { foo(); });

instead of 

require(["async!http://maps.googleapis.com/maps/api/js?sensor=false!callback"], function() { 
    required(["google/gmaps"],function() {
        foo();
    }
});
