### PR TITLE
Allow route origins to be a string or array

### DIFF
--- a/gmaps.js
+++ b/gmaps.js
@@ -1010,7 +1010,7 @@ if(window.google && window.google.maps){
 
         var request_options =  extend_object(base_options, options);
 
-        request_options.origin = new google.maps.LatLng(options.origin[0], options.origin[1]);
+        request_options.origin = /string/.test(typeof options.origin) ? options.origin : new google.maps.LatLng(options.origin[0], options.origin[1]);
         request_options.destination = new google.maps.LatLng(options.destination[0], options.destination[1]);
         request_options.travelMode = travelMode;
         request_options.unitSystem = unitSystem;


### PR DESCRIPTION
maps will automatically geocode an origin or destination that is a 
string. Now routes can be drawn with lat lng array or an input string.
