### PR TITLE
Allow initialising GMaps without new.

### DIFF
--- a/lib/gmaps.core.js
+++ b/lib/gmaps.core.js
@@ -128,6 +128,8 @@ var GMaps = (function(global) {
   var doc = document;
 
   var GMaps = function(options) {
+    if (!this) return new GMaps(options);
+
     options.zoom = options.zoom || 15;
     options.mapType = options.mapType || 'roadmap';
 


### PR DESCRIPTION
Ran into weird error, was trying to debug it and actually the issue was in no `new` stuff.
