### PR TITLE
Fixed name display for styled maps

### DIFF
--- a/lib/gmaps.styles.js
+++ b/lib/gmaps.styles.js
@@ -1,5 +1,5 @@
 GMaps.prototype.addStyle = function(options) {
-  var styledMapType = new google.maps.StyledMapType(options.styles, options.styledMapName);
+  var styledMapType = new google.maps.StyledMapType(options.styles, { name: options.styledMapName });
 
   this.map.mapTypes.set(options.mapTypeId, styledMapType);
 };


### PR DESCRIPTION
StyledMapType takes an object { name: ... } as second paramter, see https://developers.google.com/maps/documentation/javascript/styling#creating_a_styledmaptype
