### PR TITLE
adds support for string arrays to arrayToLatLng

### DIFF
--- a/lib/gmaps.core.js
+++ b/lib/gmaps.core.js
@@ -84,7 +84,7 @@ var arrayToLatLng = function(coords, useGeoJSON) {
   var i;
 
   for (i = 0; i < coords.length; i++) {
-    if (coords[i].length > 0 && typeof(coords[i][0]) != "number") {
+    if (coords[i].length > 0 && typeof(coords[i][0]) == "object") {
       coords[i] = arrayToLatLng(coords[i], useGeoJSON);
     }
     else {


### PR DESCRIPTION
I had an issue calling getElevations with Bi-dimensional array of latitudes and longitudes that were in string and I was getting Uncaught RangeError: Maximum call stack size exceeded with arrayToLatLng. Since the original API accepts strings as well gmaps should support it too.

I could made the if to be `number` or `string`, but I think this is better. Your call.
