### PR TITLE
FitZoom only use visible markers

### DIFF
--- a/gmaps.js
+++ b/gmaps.js
@@ -398,7 +398,9 @@ var GMaps = (function(global) {
           i;
 
       for (i = 0; i < markers_length; i++) {
-        latLngs.push(this.markers[i].getPosition());
+        if(typeof(this.markers[i].visible) === 'boolean' && this.markers[i].visible) {
+          latLngs.push(this.markers[i].getPosition());
+        }
       }
 
       this.fitLatLngBounds(latLngs);

--- a/lib/gmaps.core.js
+++ b/lib/gmaps.core.js
@@ -390,7 +390,9 @@ var GMaps = (function(global) {
           i;
 
       for (i = 0; i < markers_length; i++) {
-        latLngs.push(this.markers[i].getPosition());
+        if(typeof(this.markers[i].visible) === 'boolean' && this.markers[i].visible) {
+          latLngs.push(this.markers[i].getPosition());
+        }
       }
 
       this.fitLatLngBounds(latLngs);


### PR DESCRIPTION
Set the FitZoom method that it only get the visible markers.
