### PR TITLE
Fix: Cannot set property 'width' of undefined

### DIFF
--- a/lib/gmaps.core.js
+++ b/lib/gmaps.core.js
@@ -176,7 +176,7 @@ var GMaps = (function(global) {
     if (typeof(options.el) === 'string' || typeof(options.div) === 'string') {
       this.el = getElementById(container_id, options.context);
     } else {
-      this.el = container_id;
+      this.el = container_id[0];
     }
 
     if (typeof(this.el) === 'undefined' || this.el === null) {


### PR DESCRIPTION
"Cannot set property 'width' of undefined" 

It was giving an error when container_id is an object.
