### PR TITLE
Convert featureType and elementType toLowerCase

### DIFF
--- a/lib/gmaps.static.js
+++ b/lib/gmaps.static.js
@@ -157,12 +157,12 @@ GMaps.staticMapURL = function(options){
   if (styles) {
     for (var i = 0; i < styles.length; i++) {
       var styleRule = [];
-      if (styles[i].featureType && styles[i].featureType != 'all' ) {
-        styleRule.push('feature:' + styles[i].featureType);
+      if (styles[i].featureType){
+        styleRule.push('feature:' + styles[i].featureType.toLowerCase());
       }
 
-      if (styles[i].elementType && styles[i].elementType != 'all') {
-        styleRule.push('element:' + styles[i].elementType);
+      if (styles[i].elementType) {
+        styleRule.push('element:' + styles[i].elementType.toLowerCase());
       }
 
       for (var j = 0; j < styles[i].stylers.length; j++) {


### PR DESCRIPTION
Turns out elementType and featureType are case sensitive, where in the normal API this is not a problem.
