### PR TITLE
Update default control styles and provide option to disable them

### DIFF
--- a/gmaps.js
+++ b/gmaps.js
@@ -14,7 +14,7 @@
  * GMaps.js v0.4.9
  * http://hpneo.github.com/gmaps/
  *
- * Copyright 2013, Gustavo Leon
+ * Copyright 2014, Gustavo Leon
  * Released under the MIT License.
  */
 
@@ -480,9 +480,12 @@ GMaps.prototype.createControl = function(options) {
   var control = document.createElement('div');
 
   control.style.cursor = 'pointer';
-  control.style.fontFamily = 'Arial, sans-serif';
-  control.style.fontSize = '13px';
-  control.style.boxShadow = 'rgba(0, 0, 0, 0.398438) 0px 2px 4px';
+  
+  if (options.disableDefaultStyles !== true) {
+    control.style.fontFamily = 'Roboto, Arial, sans-serif';
+    control.style.fontSize = '11px';
+    control.style.boxShadow = 'rgba(0, 0, 0, 0.298039) 0px 1px 4px -1px';
+  }
 
   for (var option in options.style) {
     control.style[option] = options.style[option];
@@ -693,24 +696,27 @@ GMaps.prototype.removeMarker = function(marker) {
   return marker;
 };
 
-GMaps.prototype.removeMarkers = function(collection) {
-  var collection = (collection || this.markers);
-
-  for (var i = 0;i < this.markers.length; i++) {
-    if(this.markers[i] === collection[i]) {
+GMaps.prototype.removeMarkers = function (collection) {
+  if(typeof collection == 'undefined') {
+    for(var i = 0; i < this.markers.length; i++) {
       this.markers[i].setMap(null);
     }
-  }
-
-  var new_markers = [];
-
-  for (var i = 0;i < this.markers.length; i++) {
-    if(this.markers[i].getMap() != null) {
-      new_markers.push(this.markers[i]);
+    var new_markers = [];
+    this.markers = new_markers;
+  } else {
+    for(var i = 0; i < this.markers.length; i++) {
+      if(this.markers[i] === collection[i]) {
+        this.markers[i].setMap(null);
+      }
     }
+    var new_markers = [];
+    for(var i = 0; i < this.markers.length; i++) {
+      if(this.markers[i].getMap() != null) {
+        new_markers.push(this.markers[i]);
+      }
+    }
+    this.markers = new_markers;
   }
-
-  this.markers = new_markers;
 };
 
 GMaps.prototype.drawOverlay = function(options) {

--- a/lib/gmaps.controls.js
+++ b/lib/gmaps.controls.js
@@ -2,9 +2,12 @@ GMaps.prototype.createControl = function(options) {
   var control = document.createElement('div');
 
   control.style.cursor = 'pointer';
-  control.style.fontFamily = 'Arial, sans-serif';
-  control.style.fontSize = '13px';
-  control.style.boxShadow = 'rgba(0, 0, 0, 0.398438) 0px 2px 4px';
+  
+  if (options.disableDefaultStyles !== true) {
+    control.style.fontFamily = 'Roboto, Arial, sans-serif';
+    control.style.fontSize = '11px';
+    control.style.boxShadow = 'rgba(0, 0, 0, 0.298039) 0px 1px 4px -1px';
+  }
 
   for (var option in options.style) {
     control.style[option] = options.style[option];

--- a/test/index.html
+++ b/test/index.html
@@ -19,6 +19,7 @@
   <script type="text/javascript" src="spec/StyleSpec.js"></script>
   <script type="text/javascript" src="spec/StreetViewSpec.js"></script>
   <script type="text/javascript" src="spec/EventSpec.js"></script>
+  <script type="text/javascript" src="spec/ControlSpec.js"></script>
 
   <script type="text/javascript">
     (function() {

--- a/test/spec/ControlSpec.js
+++ b/test/spec/ControlSpec.js
@@ -1,0 +1,32 @@
+describe('Creating custom map controls', function () {
+  var map;
+
+  beforeEach(function() {
+    map = map || new GMaps({
+      el : '#basic-map',
+      lat: -12.0433,
+      lng: -77.0283,
+      zoom: 12
+    });
+  });
+
+  it('should add default styles for the control', function () {
+    map.addControl({
+      position: 'top_right',
+      content: 'Geolocate'
+    });
+
+    expect(map.controls[0].style.fontFamily).not.toEqual('');
+  });
+
+  it('should leave off default styles if requested', function () {
+    map.addControl({
+      position: 'top_right',
+      disableDefaultStyles: true,
+      content: '<i class="icon"></i>'
+    });
+
+    expect(map.controls[1].style.fontFamily).toEqual('');
+  });
+
+});


### PR DESCRIPTION
This PR updates the default control styles to match those in the recent Google Maps release.

Additionally, this adds a way to disable default control styles by passing an additional option:

``` javascript
map.addControl({
  position: 'top_right',
  content: '<i class="icon-location"></i>',
  disableDefaultStyles: true
});
```

Why? Because in order to do _truly_ custom controls, it's likely that you'll override the defaults (`font-family`, `font-size`, `box-shadow`) anyways. As it stands it's necessary to use `!important` in your stylesheet in order to override those inline styles… ugly. A common use case is demonstrated above: using an icon in place of text content for a marker.
