### PR TITLE
Removed http:

### DIFF
--- a/gmaps.js
+++ b/gmaps.js
@@ -1572,7 +1572,7 @@ GMaps.prototype.toImage = function(options) {
 GMaps.staticMapURL = function(options){
   var parameters = [],
       data,
-      static_root = 'http://maps.googleapis.com/maps/api/staticmap';
+      static_root = '//maps.googleapis.com/maps/api/staticmap';
 
   if (options.url) {
     static_root = options.url;


### PR DESCRIPTION
Removed the http so the library (Google Maps 'call') will also work under SSL without warnings