### PR TITLE
Adds ability to listen for clicks on overlays

### DIFF
--- a/examples/overlays.html
+++ b/examples/overlays.html
@@ -43,6 +43,7 @@
       <p>You must define <strong>latitude</strong>, <strong>longitude</strong> and the <strong>content</strong> of the map overlay.</p>
       <p><span class="label notice">Note: </span>Also, you must define a <strong>height</strong> to the <strong>content</strong>.</p>
       <p><span class="label notice">Note: </span>Also, you can define a <code>verticalAlign</code>, which can be <code>top</code>, <code>middle</code> or <code>bottom</code>, and <code>horizontalAlign</code>, which can be <code>left</code>, <code>center</code> or <code>right</code>.</p>
+      <p><span class="label notice">Note: </span>Also, you can define a <code>click</code> callback method, which will be triggered when the overlay's DOM element is clicked.</p>
     </div>
   </div>
 </body>

--- a/gmaps.js
+++ b/gmaps.js
@@ -768,6 +768,12 @@ GMaps.prototype.drawOverlay = function(options) {
       })(el, stop_overlay_events[ev]);
     }
 
+    if (options.click) {
+      google.maps.event.addDomListener(overlay.el, 'click', function() {
+        options.click.apply(overlay, [overlay]);
+      });
+    }
+
     google.maps.event.trigger(this, 'ready');
   };
 

--- a/lib/gmaps.overlays.js
+++ b/lib/gmaps.overlays.js
@@ -43,6 +43,12 @@ GMaps.prototype.drawOverlay = function(options) {
       })(el, stop_overlay_events[ev]);
     }
 
+    if (options.click) {
+      google.maps.event.addDomListener(overlay.el, 'click', function() {
+        options.click.apply(overlay, [overlay]);
+      });
+    }
+
     google.maps.event.trigger(this, 'ready');
   };
 

--- a/test/spec/OverlaySpec.js
+++ b/test/spec/OverlaySpec.js
@@ -27,4 +27,42 @@ describe("Drawing HTML overlays", function() {
   it("should add the overlay in the current map", function() {
     expect(overlay.getMap()).toEqual(map_with_overlays.map);
   });
+
+  describe("With events", function() {
+    var callbacks, overlayWithClick;
+
+    beforeEach(function() {
+      callbacks = {
+        onclick: function() {
+          console.log('Clicked the overlay');
+        }
+      };
+
+      spyOn(callbacks, 'onclick').andCallThrough();
+
+      overlayWithClick = map_with_overlays.drawOverlay({
+        lat: map_with_overlays.getCenter().lat(),
+        lng: map_with_overlays.getCenter().lng(),
+        content: '<p>Clickable overlay</p>',
+        click: callbacks.onclick
+      });
+    });
+
+    it("should respond to click event", function() {
+      var domIsReady = false;
+
+      google.maps.event.addListenerOnce(overlayWithClick, "ready", function () {
+        domIsReady = true;
+      });
+
+      waitsFor(function () {
+        return domIsReady;
+      }, "the overlay's DOM element to be ready", 10000);
+
+      runs(function () {
+        google.maps.event.trigger(overlayWithClick.el, "click");
+        expect(callbacks.onclick).toHaveBeenCalled();
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR adds the ability to pass a `click` option into the `drawOverlay`
method in order to perform some action when an overlay's DOM element is clicked.
An accompanying test and documentation has been added.
### Use Case

When adding complex markers to a map, ones that use custom HTML/CSS, for
instance, it is necessary to use overlays rather than markers. That being the
case, it is desirable that a developer be able to easily listen to click events
on those overlays the same as they would on a standard marker.
### Example Syntax

``` javascript
map.drawOverlay({
  latitude: 0,
  longitude: 0,
  content: '<div class="map-marker">Some content</div>',
  click: function () {
    console.log('Clicked a marker');
  }
});
```
