### PR TITLE
Display infoWindow on click or mouseover.

### DIFF
--- a/gmaps.js
+++ b/gmaps.js
@@ -554,7 +554,7 @@ GMaps.prototype.createMarker = function(options) {
   marker.fences = fences;
 
   if (options.infoWindow) {
-    marker.infoWindow = new google.maps.InfoWindow(options.infoWindow);
+    marker.infoWindow = (options.infoWindow.custom) ? options.infoWindow.custom : new google.maps.InfoWindow(options.infoWindow);
 
     var info_window_events = ['closeclick', 'content_changed', 'domready', 'position_changed', 'zindex_changed'];
 

--- a/gmaps.js
+++ b/gmaps.js
@@ -554,7 +554,7 @@ GMaps.prototype.createMarker = function(options) {
   marker.fences = fences;
 
   if (options.infoWindow) {
-    marker.infoWindow = (options.infoWindow.custom) ? options.infoWindow.custom : new google.maps.InfoWindow(options.infoWindow);
+    marker.infoWindow = new google.maps.InfoWindow(options.infoWindow);
 
     var info_window_events = ['closeclick', 'content_changed', 'domready', 'position_changed', 'zindex_changed'];
 

--- a/lib/gmaps.markers.js
+++ b/lib/gmaps.markers.js
@@ -23,7 +23,7 @@ GMaps.prototype.createMarker = function(options) {
   marker.fences = fences;
 
   if (options.infoWindow) {
-    marker.infoWindow = new google.maps.InfoWindow(options.infoWindow);
+    marker.infoWindow = (options.infoWindow.custom) ? options.infoWindow.custom : new google.maps.InfoWindow(options.infoWindow);
 
     var info_window_events = ['closeclick', 'content_changed', 'domready', 'position_changed', 'zindex_changed'];
 

--- a/lib/gmaps.markers.js
+++ b/lib/gmaps.markers.js
@@ -66,18 +66,34 @@ GMaps.prototype.createMarker = function(options) {
     })(this.map, marker, marker_events_with_mouse[ev]);
   }
 
-  google.maps.event.addListener(marker, 'click', function() {
-    this.details = details;
+  if (options.click || marker.infoWindow) {
+    google.maps.event.addListener(marker, 'click', function () {
+      this.details = details;
 
-    if (options.click) {
-      options.click.apply(this, [this]);
-    }
+      if (options.click) {
+        options.click.apply(this, [this]);
+      }
 
-    if (marker.infoWindow) {
-      self.hideInfoWindows();
-      marker.infoWindow.open(self.map, marker);
-    }
-  });
+      if (marker.infoWindow && (!marker.infoWindow.event || (marker.infoWindow.event && marker.infoWindow.event === 'click'))) {
+        self.hideInfoWindows();
+        marker.infoWindow.open(self.map, marker);
+      }
+    });
+  }
+
+  if (options.mouseover || (marker.infoWindow && marker.infoWindow.event === 'mouseover')) {
+    google.maps.event.addListener(marker, 'mouseover', function (e) {
+      if (options.mouseover) {
+        options.mouseover.apply(this, [this]);
+      }
+
+      if (marker.infoWindow && marker.infoWindow.event === 'mouseover') {
+        self.hideInfoWindows();
+        marker.infoWindow.open(self.map, marker);
+      }
+
+    });
+  }
 
   google.maps.event.addListener(marker, 'rightclick', function(e) {
     e.marker = this;

--- a/lib/gmaps.markers.js
+++ b/lib/gmaps.markers.js
@@ -92,6 +92,13 @@ GMaps.prototype.createMarker = function(options) {
         marker.infoWindow.open(self.map, marker);
       }
 
+      if (marker.events && marker.infoWindow.addEvent) {
+          for (var i = 0; i < marker.events.length; i++) {
+              var event = marker.events[i];
+              marker.infoWindow.addEvent(event.name, event.callback);
+          }
+      }
+
     });
   }
 


### PR DESCRIPTION
This pull request allows you to display the infoWindow using either the 'click' or 'mouseover' event.
You can set this option using infoWindow.event = "mouseover". If no value it's set, it will display the infoWindow on click like it's behaving now.