### PR TITLE
- Update route drawing methods to allow 'icons' option for drawPolyline

### DIFF
--- a/lib/gmaps.routes.js
+++ b/lib/gmaps.routes.js
@@ -123,12 +123,18 @@ GMaps.prototype.drawRoute = function(options) {
     error: options.error,
     callback: function(e) {
       if (e.length > 0) {
-        self.drawPolyline({
+        var polyline_options = {
           path: e[e.length - 1].overview_path,
           strokeColor: options.strokeColor,
           strokeOpacity: options.strokeOpacity,
           strokeWeight: options.strokeWeight
-        });
+        };
+
+        if (options.hasOwnProperty("icons")) {
+          polyline_options.icons = options.icons;
+        }
+
+        self.drawPolyline(polyline_options);
         
         if (options.callback) {
           options.callback(e[e.length - 1]);
@@ -206,12 +212,18 @@ GMaps.prototype.drawSteppedRoute = function(options) {
             var steps = route.legs[0].steps;
             for (var i=0, step; step=steps[i]; i++) {
               step.step_number = i;
-              self.drawPolyline({
+              var polyline_options = {
                 path: step.path,
                 strokeColor: options.strokeColor,
                 strokeOpacity: options.strokeOpacity,
                 strokeWeight: options.strokeWeight
-              });
+              };
+
+              if (options.hasOwnProperty("icons")) {
+                polyline_options.icons = options.icons;
+              }
+
+              self.drawPolyline(polyline_options);
               options.step(step, (route.legs[0].steps.length - 1));
             }
           }
@@ -229,12 +241,18 @@ GMaps.prototype.drawSteppedRoute = function(options) {
       var steps = options.route.legs[0].steps;
       for (var i=0, step; step=steps[i]; i++) {
         step.step_number = i;
-        self.drawPolyline({
+        var polyline_options = {
           path: step.path,
           strokeColor: options.strokeColor,
           strokeOpacity: options.strokeOpacity,
           strokeWeight: options.strokeWeight
-        });
+        };
+
+        if (options.hasOwnProperty("icons")) {
+          polyline_options.icons = options.icons;
+        }
+
+        self.drawPolyline(polyline_options);
         options.step(step);
       }
     }
@@ -252,12 +270,18 @@ GMaps.Route = function(options) {
   this.steps = this.route.legs[0].steps;
   this.steps_length = this.steps.length;
 
-  this.polyline = this.map.drawPolyline({
+  var polyline_options = {
     path: new google.maps.MVCArray(),
     strokeColor: options.strokeColor,
     strokeOpacity: options.strokeOpacity,
     strokeWeight: options.strokeWeight
-  }).getPath();
+  };
+
+  if (options.hasOwnProperty("icons")) {
+    polyline_options.icons = options.icons;
+  }
+
+  this.polyline = this.map.drawPolyline(polyline_options).getPath();
 };
 
 GMaps.Route.prototype.getRoute = function(options) {


### PR DESCRIPTION
I wanted to be able to draw routes that have dashed or dotted lines and needed the 'icons' option that drawPolyline() supports. I have only tested this with the drawRoute() method, but made similar changes where it looked appropriate for drawSteppedRoute() and Gmaps.Route().