### PR TITLE
build: Removes dependency on 'grunt-cli' having to be installed globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "the easiest way to use Google Maps",
   "main": "gmaps.js",
   "scripts": {
-    "test": "grunt test --verbose"
+    "test": "./node_modules/.bin/grunt test --verbose"
   },
   "repository": {
     "type": "git",
@@ -18,10 +18,11 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-jasmine": "~0.5.1",
-    "grunt-contrib-watch": "~0.4.4",
     "grunt-contrib-jshint": "~0.6.0",
+    "grunt-contrib-watch": "~0.4.4",
     "grunt-umd": "~1.3.0"
   }
 }


### PR DESCRIPTION
Hey @hpneo, ¿cómo va tío? :)
In this PR I'm removing the need to have 'grunt-cli' installed global to run the tests using: `npm test`