### PR TITLE
url hash support

### DIFF
--- a/gmaps.js
+++ b/gmaps.js
@@ -1925,6 +1925,19 @@ GMaps.prototype.createPanorama = function(streetview_options) {
 
   return this.panorama;
 };
+/* Usage: map.getURLHash(); */
+GMaps.prototype.getURLHash = function() {
+  var str = location.hash;
+  if( str != '' ){
+    this.setCenter( str.substring((str.indexOf("/")+1), str.lastIndexOf("/")), str.substring((str.lastIndexOf("/")+1), str.length) );
+    this.setZoom( parseInt( str.substring( 1, str.indexOf( "/" ) ) ) );
+  }
+  
+  this.on('bounds_changed', function(){
+    var hash = '#'+this.getZoom()+'/'+this.getCenter().lat()+'/'+this.getCenter().lng();
+    location.replace(hash);
+  });
+};
 
 GMaps.createPanorama = function(options) {
   var el = getElementById(options.el, options.context);


### PR DESCRIPTION
zoom, lat and lng from url:
[http://localhost/gmaps/#18/10.444112174678937/-64.17193496227266](http://localhost/gmaps/#18/10.444112174678937/-64.17193496227266)

bounds_changed event used for change hash url
usage:
```javascript
var map = new GMaps({
  div: '#map',
  lat: -12.043333,
  lng: -77.028333
});
map.getURLHash();
```