### PR TITLE
Revert "Added getPanoramaByLocation and a check around option"

### DIFF
--- a/lib/gmaps.streetview.js
+++ b/lib/gmaps.streetview.js
@@ -14,17 +14,12 @@ GMaps.prototype.createPanorama = function(streetview_options) {
 GMaps.createPanorama = function(options) {
   var el = getElementById(options.el, options.context);
 
-  var panoramaService = new google.maps.StreetViewService();
-  var checkaround = options.checkaround || 50;
-  var panorama = null;
-
   options.position = new google.maps.LatLng(options.lat, options.lng);
 
   delete options.el;
   delete options.context;
   delete options.lat;
   delete options.lng;
-  delete options.checkaround;
 
   var streetview_events = ['closeclick', 'links_changed', 'pano_changed', 'position_changed', 'pov_changed', 'resize', 'visible_changed'],
       streetview_options = extend_object({visible : true}, options);
@@ -33,28 +28,17 @@ GMaps.createPanorama = function(options) {
     delete streetview_options[streetview_events[i]];
   }
 
-  //get only a streetview if this one is available
-  panoramaService.getPanoramaByLocation(options.position, checkaround ,function(data, status){
-    if (status == google.maps.StreetViewStatus.OK) {
+  var panorama = new google.maps.StreetViewPanorama(el, streetview_options);
 
-      streetview_options.position = data.location.latLng;
-
-      panorama = new google.maps.StreetViewPanorama(el, streetview_options);
-
-      for (var i = 0; i < streetview_events.length; i++) {
-        (function(object, name) {
-          if (options[name]) {
-            google.maps.event.addListener(object, name, function(){
-              options[name].apply(this);
-            });
-          }
-        })(panorama, streetview_events[i]);
+  for (var i = 0; i < streetview_events.length; i++) {
+    (function(object, name) {
+      if (options[name]) {
+        google.maps.event.addListener(object, name, function(){
+          options[name].apply(this);
+        });
       }
-      panorama.setVisible(true);
-      return panorama;
-    // no result
-    } else {
-      return false;
-    }
-  });
+    })(panorama, streetview_events[i]);
+  }
+
+  return panorama;
 };


### PR DESCRIPTION
Reverts hpneo/gmaps#398

I've just realized that `GMaps.createPanorama` needs to return an object, and this change breaks this method, since it uses an async method that can't return the panorama object for `GMaps.prototype.createPanorama`.