### PR TITLE
Add uglify step to grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,6 +62,17 @@ module.exports = function(grunt) {
       all : ['Gruntfile.js']
     },
 
+    uglify : {
+      options : {
+        sourceMap : true
+      },
+      all : {
+        files: {
+           'gmaps.min.js': [ 'gmaps.js' ]
+        }
+      }
+    },
+
     umd : {
       all : {
         src : 'gmaps.js',
@@ -78,8 +89,9 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-jasmine');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-umd');
 
   grunt.registerTask('test', ['jshint', 'jasmine']);
-  grunt.registerTask('default', ['test', 'concat', 'umd']);
+  grunt.registerTask('default', ['test', 'concat', 'umd', 'uglify']);
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-jasmine": "~0.5.1",
     "grunt-contrib-jshint": "~0.6.0",
+    "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "~0.4.4",
     "grunt-umd": "~1.3.0"
   }


### PR DESCRIPTION
This generates a minified js file together with a source map.
It saves about half of the filesize (30K vs. 58K)

I did not add the files to the .gitignore and also did not check in the minified
minified versions.