### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Changelog
 
 License
 ---------
-MIT License. Copyright 2012 Gustavo Leon. http://github.com/hpneo
+MIT License. Copyright 2012 Gustavo Leon. https://github.com/hpneo
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/documentation.html
+++ b/documentation.html
@@ -10,8 +10,8 @@
   <div id="header">
     <h1>gmaps.js</h1>
     <ul>
-      <li><a href="/gmaps/documentation.html">Documentation</a></li>
-      <li><a href="/gmaps/examples.html">Examples</a></li>
+      <li><a href="documentation.html">Documentation</a></li>
+      <li><a href="examples.html">Examples</a></li>
       <li><a href="https://github.com/HPNeo/gmaps/zipball/master">Download</a></li>
       <li><a href="#Change-log">Change log</a></li>
       <li><a href="http://jsfiddle.net/e52792j5/embedded/" target="blank">Try!</a></li>
@@ -82,29 +82,29 @@
     <div id="content">
       <h3>Documentation</h3>
       <h4 id="GMaps-div">div — HTMLDivElement</h4>
-      
+
       <h4 id="GMaps-controls">controls — Array</h4>
       <p>Collection of custom controls in the Map.</p>
-      
+
       <h4 id="GMaps-overlays">overlays — Array</h4>
-      
+
       <h4 id="GMaps-layers">layers — Array</h4>
 
       <h4 id="GMaps-singleLayers">singleLayers — Object</h4>
-      
+
       <h4 id="GMaps-markers">markers — Array</h4>
-      
+
       <h4 id="GMaps-polylines">polylines — Array</h4>
-      
+
       <h4 id="GMaps-routes">routes — Array</h4>
-      
+
       <h4 id="GMaps-polygons">polygons — Array</h4>
-      
+
       <h4 id="GMaps-zoom">zoom — Integer</h4>
-      
+
       <h4 id="GMaps-map">map — google.maps.Map</h4>
       <p>Native google.maps.Map object.</p>
-      
+
       <h4 id="GMaps-setContextMenu">setContextMenu</h4>
       <p>Set a context menu for the entire Map or a marker.</p>
       <p><code>setContextMenu</code> accepts a hash of options.</p>
@@ -157,16 +157,16 @@
           </tr>
         </tbody>
       </table>
-      
+
       <h4 id="GMaps-hideContextMenu">hideContextMenu</h4>
       <p>Hide current context menu displayed.</p>
 
       <h4 id="GMaps-refresh">refresh</h4>
       <p>Trigger the <code>resize</code> event of a Map. Useful when the Map is created in a dynamic container</p>
-      
+
       <h4 id="GMaps-fitZoom">fitZoom</h4>
       <p>Fit zoom level to show all markers in the viewport.</p>
-      
+
       <h4 id="GMaps-fitLatLngBounds">fitLatLngBounds</h4>
       <p>Fit zoom level to show a bound of coordinates.</p>
       <p><code>fitLatLngBounds</code> accepts 1 parameter.</p>
@@ -187,7 +187,7 @@
           </tr>
         </tbody>
       </table>
-      
+
       <h4 id="GMaps-setCenter">setCenter</h4>
       <p>Set center in the Map.</p>
       <p><code>setCenter</code> accepts 3 parameters.</p>

--- a/examples.html
+++ b/examples.html
@@ -9,7 +9,7 @@
   <a href="https://github.com/hpneo/gmaps" target="blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="./">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -25,7 +25,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/context_menu.html
+++ b/examples/context_menu.html
@@ -46,7 +46,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/custom_controls.html
+++ b/examples/custom_controls.html
@@ -52,7 +52,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/fusion_tables.html
+++ b/examples/fusion_tables.html
@@ -42,7 +42,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/geocoding.html
+++ b/examples/geocoding.html
@@ -40,7 +40,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/geofences.html
+++ b/examples/geofences.html
@@ -48,7 +48,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/geofences.html
+++ b/examples/geofences.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title>gmaps.js &mdash; the easiest way to use Google Maps</title>
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=true"></script>
+  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=true"></script>
   <script type="text/javascript" src="../gmaps.js"></script>
   <script type="text/javascript" src="../prettify/prettify.js"></script>
-  <link href='http://fonts.googleapis.com/css?family=Convergence|Bitter|Droid+Sans|Ubuntu+Mono' rel='stylesheet' type='text/css' />
+  <link href='//fonts.googleapis.com/css?family=Convergence|Bitter|Droid+Sans|Ubuntu+Mono' rel='stylesheet' type='text/css' />
   <link href='../styles.css' rel='stylesheet' type='text/css' />
   <link href='../prettify/prettify.css' rel='stylesheet' type='text/css' />
   <link rel="stylesheet" type="text/css" href="examples.css" />

--- a/examples/geojson_polygon.html
+++ b/examples/geojson_polygon.html
@@ -76,7 +76,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/geolocation.html
+++ b/examples/geolocation.html
@@ -40,7 +40,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/interacting.html
+++ b/examples/interacting.html
@@ -98,7 +98,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/json.html
+++ b/examples/json.html
@@ -23,7 +23,7 @@
 
           if (item.location.lat != undefined && item.location.lng != undefined) {
             var icon = 'https://foursquare.com/img/categories/food/default.png';
-            
+
             markers_data.push({
               lat : item.location.lat,
               lng : item.location.lng,
@@ -77,7 +77,7 @@
         }
       });
 
-      var xhr = $.getJSON('http://coffeemaker.herokuapp.com/foursquare.json?q[near]=Lima,%20PE&q[query]=Ceviche');
+      var xhr = $.getJSON('https://coffeemaker.herokuapp.com/foursquare.json?q[near]=Lima,%20PE&q[query]=Ceviche');
 
       xhr.done(printResults);
       xhr.done(loadResults);
@@ -118,9 +118,9 @@
         for (var i = 0; i < items.length; i++) {
           var item = items[i];
 
-          if (item.location.lat != undefined && item.location.lng != undefined) {
+          if (item.location.lat != undefined &amp;&amp; item.location.lng != undefined) {
             var icon = 'https://foursquare.com/img/categories/food/default.png';
-            
+
             markers_data.push({
               lat : item.location.lat,
               lng : item.location.lng,
@@ -174,7 +174,7 @@
         }
       });
 
-      var xhr = $.getJSON('http://coffeemaker.herokuapp.com/foursquare.json?q[near]=Lima,%20PE&q[query]=Ceviche');
+      var xhr = $.getJSON('https://coffeemaker.herokuapp.com/foursquare.json?q[near]=Lima,%20PE&amp;q[query]=Ceviche');
 
       xhr.done(printResults);
       xhr.done(loadResults);

--- a/examples/json.html
+++ b/examples/json.html
@@ -87,7 +87,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/kml.html
+++ b/examples/kml.html
@@ -39,7 +39,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/map_events.html
+++ b/examples/map_events.html
@@ -32,7 +32,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/map_types.html
+++ b/examples/map_types.html
@@ -45,7 +45,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/map_types.html
+++ b/examples/map_types.html
@@ -19,23 +19,15 @@
         lat: -12.043333,
         lng: -77.028333,
         mapTypeControlOptions: {
-          mapTypeIds : ["hybrid", "roadmap", "satellite", "terrain", "osm", "cloudmade"]
+          mapTypeIds : ["hybrid", "roadmap", "satellite", "terrain", "osm"]
         }
       });
       map.addMapType("osm", {
         getTileUrl: function(coord, zoom) {
-          return "http://tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
+          return "https://a.tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
         },
         tileSize: new google.maps.Size(256, 256),
         name: "OpenStreetMap",
-        maxZoom: 18
-      });
-      map.addMapType("cloudmade", {
-        getTileUrl: function(coord, zoom) {
-          return "http://b.tile.cloudmade.com/8ee2a50541944fb9bcedded5165f09d9/1/256/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
-        },
-        tileSize: new google.maps.Size(256, 256),
-        name: "CloudMade",
         maxZoom: 18
       });
       map.setMapTypeId("osm");
@@ -61,7 +53,7 @@
         <p>You can define many map types from external map services, like OpenStreetMap:</p>
         <pre class="prettyprint">map.addMapType("osm", {
   getTileUrl: function(coord, zoom) {
-    return "http://tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
+    return "https://a.tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
   },
   tileSize: new google.maps.Size(256, 256),
   name: "OpenStreetMap",

--- a/examples/markers.html
+++ b/examples/markers.html
@@ -47,7 +47,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/new_style.html
+++ b/examples/new_style.html
@@ -26,7 +26,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/overlay_map_types.html
+++ b/examples/overlay_map_types.html
@@ -46,7 +46,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/overlays.html
+++ b/examples/overlays.html
@@ -32,7 +32,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/polygon.html
+++ b/examples/polygon.html
@@ -38,7 +38,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/polylines.html
+++ b/examples/polylines.html
@@ -37,7 +37,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/routes.html
+++ b/examples/routes.html
@@ -33,7 +33,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/routes_advanced.html
+++ b/examples/routes_advanced.html
@@ -45,7 +45,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>
@@ -76,7 +76,7 @@
         strokeColor: '#131540',
         strokeOpacity: 0.6,
         strokeWeight: 6
-      });  
+      });
     });
   }
 });</pre>

--- a/examples/static.html
+++ b/examples/static.html
@@ -26,7 +26,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/static_markers.html
+++ b/examples/static_markers.html
@@ -31,7 +31,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/static_polylines.html
+++ b/examples/static_polylines.html
@@ -42,7 +42,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/streetview.html
+++ b/examples/streetview.html
@@ -25,7 +25,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/examples/travel_route.html
+++ b/examples/travel_route.html
@@ -72,7 +72,7 @@
 <body>
   <div id="header">
     <h1>
-      <a href="http://hpneo.github.com/gmaps">gmaps.js</a>
+      <a href="../">gmaps.js</a>
     </h1>
     <h2>Google Maps API with less pain and more fun</h2>
   </div>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <br />
     <a href="http://xenda.pe" target="blank"><img src="xenda-black.png" /></a>
     <br />
-    MIT License. Copyright 2012 Gustavo Leon. <a href="http://github.com/hpneo" target="blank">http://github.com/hpneo</a>
+    MIT License. Copyright 2012 Gustavo Leon. <a href="https://github.com/hpneo" target="blank">https://github.com/hpneo</a>
   </p>
 </body>
 </html>


### PR DESCRIPTION
I noticed a few things the other day when checking out this library for the first time, and #421 inspired me to actually fix the issues (instead of just whitelisting the website and moving on).

- Fixes non-HTTPS assets being blocked by the browser when viewing documentation under HTTPS.
- Fixes mixed-content warnings under HTTPS when using the OpenStreetMap Tile API.
- Remove the CloudMade example as the API key appears to be inactive.
- Use relative links for internal documentation pages.

This should close #421.