### PR TITLE
remove obsolete sensor parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Quick Start
 <html>
 <head>
   <title></title>
-  <script src="http://maps.google.com/maps/api/js?sensor=true"></script>
+  <script src="http://maps.google.com/maps/api/js"></script>
   <script src="gmaps.js"></script>
   <style type="text/css">
     #map {


### PR DESCRIPTION
According to https://developers.google.com/maps/documentation/javascript/error-messages

SensorNotRequired	Warning	
The sensor parameter is no longer required for the Google Maps JavaScript API. It won't prevent the Google Maps JavaScript API from working correctly, but we recommend that you remove the sensor parameter from the script element.