### PR TITLE
Crash before invoking:

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -295,6 +295,16 @@ class GMaps {
         this.buildContextMenu('map', event);
       }
     });
+
+    const googleMapsMapMethods = Object.keys(google.maps.Map.prototype)
+        .filter(key => (typeof google.maps.Map.prototype[key] === 'function' && !GMaps.prototype[key]));
+
+    googleMapsMapMethods.forEach((methodName) => {
+      // eslint-disable-next-line func-names
+      GMaps.prototype[methodName] = function (...args) {
+        return this.map[methodName].apply(this.map, args);
+      };
+    });
   }
 
   buildContextMenuHTML(control, event) {
@@ -501,15 +511,5 @@ class GMaps {
 }
 
 GMaps.contextMenus = {};
-
-const googleMapsMapMethods = Object.keys(google.maps.Map.prototype)
-  .filter(key => (typeof google.maps.Map.prototype[key] === 'function' && !GMaps.prototype[key]));
-
-googleMapsMapMethods.forEach((methodName) => {
-  // eslint-disable-next-line func-names
-  GMaps.prototype[methodName] = function (...args) {
-    return this.map[methodName].apply(this.map, args);
-  };
-});
 
 export default GMaps;


### PR DESCRIPTION
Sometimes, before we create any gmaps object, there is an error saying google is undefined (google maps failed to load and gmaps is already trying to execute its script). Moving this piece of code to constructor solves the problem.