### PR TITLE
docs: Fix simple typo, suport -> support

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Changelog
 0.2.5
 -----------------------
 * Add support to all marker events
-* Add suport for animations at show and remove overlays
+* Add support for animations at show and remove overlays
 
 0.2.4.1
 -----------------------


### PR DESCRIPTION
There is a small typo in README.md.

Should read `support` rather than `suport`.

